### PR TITLE
feat: refactor login tests to use external JSON fixture for user data

### DIFF
--- a/playwright/fixtures/usuarios.json
+++ b/playwright/fixtures/usuarios.json
@@ -1,0 +1,18 @@
+{
+  "validos": {
+    "admin": {
+      "email": "admin@donjulio.com",
+      "password": "Admin1234!"
+    }
+  },
+  "invalidos": {
+    "emailIncorrecto": {
+      "email": "noexiste@test.com",
+      "password": "123456"
+    },
+    "passwordIncorrecto": {
+      "email": "user@test.com",
+      "password": "wrongpass"
+    }
+  }
+}

--- a/playwright/tests/specs/login-invalido.spec.ts
+++ b/playwright/tests/specs/login-invalido.spec.ts
@@ -1,18 +1,5 @@
 import { test, expect } from '@playwright/test'
-
-// Datos de usuarios inline (evita problemas con JSON imports)
-const usuarios = {
-  invalidos: {
-    emailIncorrecto: {
-      email: "noexiste@test.com",
-      password: "123456"
-    },
-    passwordIncorrecto: {
-      email: "user@test.com",
-      password: "wrongpass"
-    }
-  }
-}
+import usuarios from '../../fixtures/usuarios.json' with { type: 'json' }
 
 test.describe('Login Inválido - Playwright', () => {
   test('Login falla con email incorrecto', async ({ page }) => {

--- a/playwright/tests/specs/login-valido.spec.ts
+++ b/playwright/tests/specs/login-valido.spec.ts
@@ -1,14 +1,5 @@
 import { test, expect } from '@playwright/test'
-
-// Datos de usuarios inline (evita problemas con JSON imports)
-const usuarios = {
-  validos: {
-    admin: {
-      email: "admin@donjulio.com",
-      password: "Admin1234!"
-    }
-  }
-}
+import usuarios from '../../fixtures/usuarios.json' with { type: 'json' }
 
 test.describe('Login Válido - Playwright', () => {
   test('Login exitoso con usuario válido', async ({ page }) => {

--- a/playwright/tests/specs/nevegacion-admin.spec.ts
+++ b/playwright/tests/specs/nevegacion-admin.spec.ts
@@ -1,14 +1,5 @@
 import { test, expect } from '@playwright/test'
-
-// Definir datos inline (más simple)
-const usuarios = {
- validos: {
-    admin: {
-      email: "admin@donjulio.com",
-      password: "Admin1234!"
-    }
-  }
-}
+import usuarios from '../../fixtures/usuarios.json' with { type: 'json' }
 
 test.describe('Navegación Post-Login - Playwright', () => {
   


### PR DESCRIPTION
agregué la importación del .json en lugar de crear los usuarios en el mismo test